### PR TITLE
[closes #12] - Only support CreateReactApp for this repo

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -24,11 +24,7 @@
     "9.5",
     "9.4"
   ],
-  "js_task_runner": [
-    "None",
-    "CreateReactApp",
-    "Gulp"
-  ],
+  "js_task_runner": "CreateReactApp",
   "cloud_provider": [
     "AWS",
     "GCP",


### PR DESCRIPTION
This cookiecutter is specific for react.  Closes #12 